### PR TITLE
Add Validate Subparser, fix --help bug

### DIFF
--- a/Solutions/dev/runner.py
+++ b/Solutions/dev/runner.py
@@ -16,6 +16,7 @@ from util.pcargparse import PCArgParseFactory
 from util.subparsers import writers as writersSubparser
 from util.subparsers import test as testSubparser
 from util.subparsers import package as packageSubparser
+from util.subparsers import validate as validateSubparser
 
 def parse_arguments(arguments, output=sys.stdout):
     argParser = PCArgParseFactory.get_argument_parser(output)
@@ -35,6 +36,7 @@ def parse_arguments(arguments, output=sys.stdout):
     writersSubparser.add_to_subparser_object(subparsers, baseParser)
     testSubparser.add_to_subparser_object(subparsers, baseParser)
     packageSubparser.add_to_subparser_object(subparsers, baseParser)
+    validateSubparser.add_to_subparser_object(subparsers, baseParser)
 
     if len(arguments) == 0:
         argParser.print_help()

--- a/Solutions/dev/runner.py
+++ b/Solutions/dev/runner.py
@@ -44,14 +44,18 @@ def parse_arguments(arguments, output=sys.stdout):
     else:
         try:
             args = argParser.parse_args(arguments)
+
+            if args.help:
+                argParser.print_help()
+                return None
+
             if args.func:
                 args.func(args)
-        except Exception as e: 
+
+        except Exception as e:
             print(str(e))
-            return None 
-        if args.help:
-            argParser.print_help()
             return None
+
 
         return args
 

--- a/Solutions/dev/util/subparsers/validate.py
+++ b/Solutions/dev/util/subparsers/validate.py
@@ -1,0 +1,63 @@
+###############################################################################
+# Filename: util/subparsers/validate.py
+# Author:   Brandon Milton, http://brandonio21.com
+# Date:     23 August 2016
+#
+# Contains logic for the subparser that is invoked when calling
+# $ ./runner.py validate
+###############################################################################
+import json
+from util import fileops
+from util.definitions import Definitions
+
+SUBPARSER_KEYWORD = "validate"
+
+def operate(args):
+    """
+    Takes the passed in args and delegates to the proper functionality. This is
+    set as the executable function when the `validate` subparser is used.
+
+    Arguments:
+    args: Namespace - The arguments passed via CLI
+    """
+    caseList = args.casefiles
+    validate_arg_provided_casefiles(caseList)
+
+def add_to_subparser_object(subparserObject, parentParser):
+    """
+    Adds the validate subparser to a given subparsers object and delegates validate
+    functionality to the operate() function
+
+    Arguments:
+    subparserObject - The ArgumentParser given by parser.add_subparsers() to add
+                      the validate subparser to
+    parentParser    - The parser to be included as a parent to the subparser,
+                      useful for global flags.
+    """
+    validateParser = subparserObject.add_parser(SUBPARSER_KEYWORD, parents=[parentParser])
+    validateParser.add_argument('casefiles', nargs='*')
+    validateParser.set_defaults(func=operate)
+
+def validate_arg_provided_casefiles(filePaths: list):
+    if filePaths is None or len(filePaths) == 0:
+        validate_defined_case_dir()
+    else:
+        validate_casefiles(filePaths)
+
+def validate_defined_case_dir():
+    testDir = Definitions.get_value('test_directory')
+    validate_casefiles(fileops.get_files_in_dir(testDir))
+
+def validate_casefiles(filePaths: list):
+    """
+    If there are items in the provided file paths, ensure that
+    they all contain proper JSON. Otherwise, validate all JSON
+    case files in the definitions-defined case directory.
+    """
+    for filePath in filePaths:
+        with open(filePath, 'r') as openFile:
+            try: 
+                testJson = json.loads(openFile.read())
+            except Exception as e:
+                print("Casefile {} contains JSON issues: {}".format(
+                    filePath, e))


### PR DESCRIPTION
This PR merges two commits from my working fork. The first commit introduces a new sub-command `./runner.py validate`, which simply validates all case json files and ensures they are correct. If they are not correct, an error message is displayed.

The second commit fixes a bug which caused `./runner.py --help` to not work.